### PR TITLE
use FirebaseMessaging instead of FirebaseInstanceId to get token

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationRegistrationService.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationRegistrationService.java
@@ -4,10 +4,9 @@ import android.app.IntentService;
 import android.content.Intent;
 import android.util.Log;
 
-import com.google.android.gms.tasks.OnSuccessListener;
-import com.google.firebase.iid.FirebaseInstanceId;
-import com.google.firebase.iid.InstanceIdResult;
+import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
+import com.google.firebase.messaging.FirebaseMessaging;
 
 
 import static com.dieam.reactnativepushnotification.modules.RNPushNotification.LOG_TAG;
@@ -24,12 +23,16 @@ public class RNPushNotificationRegistrationService extends IntentService {
     protected void onHandleIntent(Intent intent) {
         try {
             String SenderID = intent.getStringExtra("senderID");
-            Task<InstanceIdResult> t = FirebaseInstanceId.getInstance().getInstanceId();
-            t.addOnSuccessListener(new OnSuccessListener<InstanceIdResult>() {
+
+            FirebaseMessaging.getInstance().getToken().addOnCompleteListener(new OnCompleteListener<String>() {
                 @Override
-                public void onSuccess(InstanceIdResult instanceIdResult) {
-                    String token = instanceIdResult.getToken();
-                    sendRegistrationToken(token);
+                public void onComplete(@NonNull Task<String> task) {
+                    if (!task.isSuccessful()) {
+                        Log.e(LOG_TAG, "exception", task.getException());
+                        return;
+                    }
+
+                    sendRegistrationToken(task.getResult());
                 }
             });
         } catch (Exception e) {


### PR DESCRIPTION
I'm basically copying this fix https://github.com/zo0r/react-native-push-notification/commit/66243dd200efed95d72d2590ab3b0bf47fe22537

That commit was included in today's release of 7.3.0 but we are quite far behind that version so I just want to change as little as possible while getting our android build working again.